### PR TITLE
Issue #44 nominating users stuck on e-mail verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifndef $GIT_BRANCH
 endif
 
 # Pull correct branches for PF from local files. 
-PF_GIT_BRANCH = pf_issue_55
+PF_GIT_BRANCH = DEV_1.4.4
 PF_GIT_REPO = https://github.com/tridentli/pitchfork.git
 
 # dpkg-buildpackage calls make, so <all> should be empty.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifndef $GIT_BRANCH
 endif
 
 # Pull correct branches for PF from local files. 
-PF_GIT_BRANCH = DEV_1.4.4
+PF_GIT_BRANCH = pf_issue_55
 PF_GIT_REPO = https://github.com/tridentli/pitchfork.git
 
 # dpkg-buildpackage calls make, so <all> should be empty.

--- a/share/test/case_nomination
+++ b/share/test/case_nomination
@@ -371,6 +371,91 @@
 	<td>${logoutURI}</td>
 	<td></td>
 </tr>
+<tr>
+	<td>open</td>
+	<td>${loginURI}</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=login-username</td>
+	<td>testuser</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=login-password</td>
+	<td>${testuserPassword}</td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>id=login-button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>link=Group</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>link=test - test TG</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>link=Nominate</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=search</td>
+	<td>bob@sideshow.com</td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>name=button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=NominateNew-fullname</td>
+	<td>Sideshow Bob</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=NominateNew-affiliation</td>
+	<td>Bob's Sideshow</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=NominateNew-biography</td>
+	<td>da da da</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=NominateNew-comment</td>
+	<td>Ba Ba Ba</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=NominateNew-attestations</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>id=NominateNew-button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=-message</td>
+	<td>Member successfully nominated.</td>
+</tr>
+<tr>
+	<td>open</td>
+	<td>${logoutURI}</td>
+	<td></td>
+</tr>
 </tbody></table>
 </body>
 </html>

--- a/share/test/case_summary
+++ b/share/test/case_summary
@@ -108,7 +108,7 @@
 </tr>
 <tr>
 	<td>store</td>
-	<td>Members: 17</td>
+	<td>Members: 18</td>
 	<td>txtValue</td>
 </tr>
 <tr>
@@ -123,7 +123,7 @@
 </tr>
 <tr>
 	<td>store</td>
-	<td>Member Emails: 18</td>
+	<td>Member Emails: 19</td>
 	<td>txtValue</td>
 </tr>
 <tr>

--- a/share/test/case_vcp_pager
+++ b/share/test/case_vcp_pager
@@ -709,7 +709,7 @@
 <tr>
 	<td>assertText</td>
 	<td>//div[@id='receptacle']/div[2]/article/p[4]</td>
-	<td>exact:Offset: 0, Total: 15</td>
+	<td>exact:Offset: 0, Total: 16</td>
 </tr>
 <tr>
 	<td>clickAndWait</td>
@@ -719,7 +719,7 @@
 <tr>
 	<td>assertText</td>
 	<td>//div[@id='receptacle']/div[2]/article/p[4]</td>
-	<td>exact:Offset: 10, Total: 15</td>
+	<td>exact:Offset: 10, Total: 16</td>
 </tr>
 <tr>
 	<td>clickAndWait</td>

--- a/src/lib/user.go
+++ b/src/lib/user.go
@@ -2,6 +2,7 @@ package trident
 
 import (
 	"errors"
+
 	pf "trident.li/pitchfork/lib"
 )
 
@@ -213,6 +214,7 @@ func user_pw_menu(ctx pf.PfCtx, menu *pf.PfMenu) {
 func user_menu(ctx pf.PfCtx, menu *pf.PfMenu) {
 	m := []pf.PfMEntry{
 		{"nominate", user_nominate, 5, 5, []string{"username", "email", "bio_info", "affiliation", "descr"}, pf.PERM_USER, "Nominate New User"},
+		{"merge", user_merge, 2, 2, []string{"username_new", "username_old"}, pf.PERM_SYS_ADMIN, "Merge two user accounts"},
 	}
 
 	menu.Add(m...)

--- a/src/lib/user.go
+++ b/src/lib/user.go
@@ -214,7 +214,6 @@ func user_pw_menu(ctx pf.PfCtx, menu *pf.PfMenu) {
 func user_menu(ctx pf.PfCtx, menu *pf.PfMenu) {
 	m := []pf.PfMEntry{
 		{"nominate", user_nominate, 5, 5, []string{"username", "email", "bio_info", "affiliation", "descr"}, pf.PERM_USER, "Nominate New User"},
-		{"merge", user_merge, 2, 2, []string{"username_new", "username_old"}, pf.PERM_SYS_ADMIN, "Merge two user accounts"},
 	}
 
 	menu.Add(m...)

--- a/src/ui/vouch.go
+++ b/src/ui/vouch.go
@@ -189,9 +189,6 @@ func vouch_nominate_new(cui pu.PfUI) (msg string, err error) {
 		return
 	}
 
-        /* Verify Email address */
-        pf.User_Email_Verify(ctx, username, email)
-
 	cmd = "group nominate"
 	args = []string{grp.GetGroupName(), vouchee_ident}
 

--- a/src/ui/vouch.go
+++ b/src/ui/vouch.go
@@ -189,14 +189,6 @@ func vouch_nominate_new(cui pu.PfUI) (msg string, err error) {
 		return
 	}
 
-	cmd = "user email confirm_force"
-	args = []string{vouchee_ident, email}
-
-	msg, err = cui.HandleCmd(cmd, args)
-	if err != nil {
-		return
-	}
-
 	cmd = "group nominate"
 	args = []string{grp.GetGroupName(), vouchee_ident}
 

--- a/src/ui/vouch.go
+++ b/src/ui/vouch.go
@@ -189,6 +189,9 @@ func vouch_nominate_new(cui pu.PfUI) (msg string, err error) {
 		return
 	}
 
+        /* Verify Email address */
+        pf.User_Email_Verify(ctx, username, email)
+
 	cmd = "group nominate"
 	args = []string{grp.GetGroupName(), vouchee_ident}
 


### PR DESCRIPTION
User nominations were broken unless you were a sysadmin. 
the user email confirm_force cmd was called which requires sysadmin access. 
PF55 has re-worked things so that user.Create() now marks the member_email record as verified on nomination. 